### PR TITLE
fix: add SSH host key verification before cloning repositories

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,3 +3,4 @@ export * from './executor.js';
 export * from './filter.js';
 export * from './loop.js';
 export * from './output.js';
+export * from './ssh.js';

--- a/src/core/ssh.ts
+++ b/src/core/ssh.ts
@@ -1,0 +1,129 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { executeSync } from './executor.js';
+import * as output from './output.js';
+
+/**
+ * Extracts the SSH host from a git URL.
+ * Supports formats like:
+ *   - git@github.com:user/repo.git
+ *   - ssh://git@github.com/user/repo.git
+ *   - git@gitlab.example.com:2222:user/repo.git (custom port)
+ *
+ * Returns null for non-SSH URLs (https://, file://, etc.)
+ */
+export function extractSshHost(url: string): string | null {
+  // Skip non-SSH URLs
+  if (url.startsWith('https://') || url.startsWith('http://') || url.startsWith('file://')) {
+    return null;
+  }
+
+  // Handle ssh:// format: ssh://git@host/path or ssh://git@host:port/path
+  const sshMatch = url.match(/^ssh:\/\/[^@]+@([^/:]+)/);
+  if (sshMatch) {
+    return sshMatch[1] ?? null;
+  }
+
+  // Handle git@host:path format
+  const gitMatch = url.match(/^[^@]+@([^:]+):/);
+  if (gitMatch) {
+    return gitMatch[1] ?? null;
+  }
+
+  return null;
+}
+
+/**
+ * Extracts unique SSH hosts from a list of repository URLs.
+ */
+export function extractUniqueSshHosts(urls: string[]): string[] {
+  const hosts = new Set<string>();
+
+  for (const url of urls) {
+    const host = extractSshHost(url);
+    if (host) {
+      hosts.add(host);
+    }
+  }
+
+  return Array.from(hosts);
+}
+
+/**
+ * Checks if a host is already in the known_hosts file.
+ */
+export async function isHostKnown(host: string): Promise<boolean> {
+  const knownHostsPath = join(homedir(), '.ssh', 'known_hosts');
+
+  try {
+    const content = await readFile(knownHostsPath, 'utf-8');
+    // Check for host in various formats (plain, hashed entries won't match but that's ok)
+    const hostPatterns = [
+      new RegExp(`^${escapeRegex(host)}[,\\s]`, 'm'),
+      new RegExp(`^\\[${escapeRegex(host)}\\]:\\d+[,\\s]`, 'm'),
+    ];
+
+    return hostPatterns.some((pattern) => pattern.test(content));
+  } catch {
+    // File doesn't exist or can't be read
+    return false;
+  }
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Adds a host's SSH key to known_hosts using ssh-keyscan.
+ * Returns true if successful, false otherwise.
+ */
+export function addHostKey(host: string): boolean {
+  const knownHostsPath = join(homedir(), '.ssh', 'known_hosts');
+
+  // Use ssh-keyscan to fetch the host key and append to known_hosts
+  const result = executeSync(`ssh-keyscan -H "${host}" >> "${knownHostsPath}" 2>/dev/null`, {
+    cwd: process.cwd(),
+  });
+
+  return result.exitCode === 0;
+}
+
+/**
+ * Ensures all SSH hosts for the given repository URLs are in known_hosts.
+ * Prompts or automatically adds missing host keys.
+ *
+ * @param urls - Array of git repository URLs
+ * @returns Object with arrays of added and failed hosts
+ */
+export async function ensureSshHostsKnown(
+  urls: string[]
+): Promise<{ added: string[]; failed: string[] }> {
+  const hosts = extractUniqueSshHosts(urls);
+  const added: string[] = [];
+  const failed: string[] = [];
+
+  if (hosts.length === 0) {
+    return { added, failed };
+  }
+
+  for (const host of hosts) {
+    const known = await isHostKnown(host);
+
+    if (!known) {
+      output.info(`Adding SSH host key for ${host}...`);
+      const success = addHostKey(host);
+
+      if (success) {
+        output.success(`Added host key for ${host}`);
+        added.push(host);
+      } else {
+        output.error(`Failed to add host key for ${host}`);
+        failed.push(host);
+      }
+    }
+  }
+
+  return { added, failed };
+}

--- a/tests/integration/git.test.ts
+++ b/tests/integration/git.test.ts
@@ -10,6 +10,7 @@ vi.mock('node:fs/promises', async () => {
 
 vi.mock('../../src/core/executor.js', () => ({
   execute: vi.fn(),
+  executeSync: vi.fn(() => ({ exitCode: 0, stdout: '', stderr: '', timedOut: false })),
 }));
 
 vi.mock('../../src/core/output.js', () => ({

--- a/tests/unit/core/ssh.test.ts
+++ b/tests/unit/core/ssh.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { extractSshHost, extractUniqueSshHosts } from '../../../src/core/ssh.js';
+
+describe('ssh', () => {
+  describe('extractSshHost', () => {
+    it('extracts host from git@host:path format', () => {
+      expect(extractSshHost('git@github.com:user/repo.git')).toBe('github.com');
+      expect(extractSshHost('git@gitlab.example.com:group/project.git')).toBe('gitlab.example.com');
+    });
+
+    it('extracts host from ssh:// format', () => {
+      expect(extractSshHost('ssh://git@github.com/user/repo.git')).toBe('github.com');
+      expect(extractSshHost('ssh://git@gitlab.example.com:2222/user/repo.git')).toBe(
+        'gitlab.example.com'
+      );
+    });
+
+    it('returns null for HTTPS URLs', () => {
+      expect(extractSshHost('https://github.com/user/repo.git')).toBeNull();
+      expect(extractSshHost('http://github.com/user/repo.git')).toBeNull();
+    });
+
+    it('returns null for file:// URLs', () => {
+      expect(extractSshHost('file:///path/to/repo')).toBeNull();
+    });
+
+    it('handles various SSH user formats', () => {
+      expect(extractSshHost('ssh@bitbucket.org:user/repo.git')).toBe('bitbucket.org');
+    });
+  });
+
+  describe('extractUniqueSshHosts', () => {
+    it('extracts unique hosts from multiple URLs', () => {
+      const urls = [
+        'git@github.com:user/repo1.git',
+        'git@github.com:user/repo2.git',
+        'git@gitlab.com:user/repo3.git',
+      ];
+      const hosts = extractUniqueSshHosts(urls);
+      expect(hosts).toHaveLength(2);
+      expect(hosts).toContain('github.com');
+      expect(hosts).toContain('gitlab.com');
+    });
+
+    it('ignores non-SSH URLs', () => {
+      const urls = [
+        'git@github.com:user/repo.git',
+        'https://github.com/user/repo2.git',
+      ];
+      const hosts = extractUniqueSshHosts(urls);
+      expect(hosts).toEqual(['github.com']);
+    });
+
+    it('returns empty array for no SSH URLs', () => {
+      const urls = [
+        'https://github.com/user/repo1.git',
+        'https://gitlab.com/user/repo2.git',
+      ];
+      const hosts = extractUniqueSshHosts(urls);
+      expect(hosts).toEqual([]);
+    });
+
+    it('returns empty array for empty input', () => {
+      expect(extractUniqueSshHosts([])).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds pre-flight SSH host key verification before cloning repositories
- Automatically detects SSH URLs and extracts unique hosts
- Uses `ssh-keyscan` to add missing host keys to `~/.ssh/known_hosts`
- Prevents "Host key verification failed" errors on first clone

## Changes
- New `src/core/ssh.ts` module with utilities for SSH host handling
- Updated `clone.ts` and `update.ts` commands to verify host keys before cloning
- Added comprehensive unit tests for the new SSH module

## Test plan
- [x] All existing unit tests pass (113 tests)
- [x] New SSH tests pass (9 tests)
- [x] Lint and typecheck pass
- [ ] Manual testing: `gogo git update` on a fresh system with unknown hosts

Closes #12

🤖 Generated with [Claude Code](https://claude.ai/claude-code)