### PR TITLE
feat(validate): check configured projects exist in the working copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,25 @@ gogo npm run lint --if-present
 
 ---
 
+### `gogo validate`
+
+Validate your configuration. This runs two checks:
+
+1. **Config files** — every `.gogo` / `.gogo.*` / `.looprc` file in the current
+   directory is parsed and checked against its schema.
+2. **Working copy** — each project declared in the resolved config must have a
+   matching directory on disk.
+
+If a configured project directory is missing, validation fails with a hint:
+run `gogo migrate` if the project was moved/renamed in the config, or
+`gogo git update` to clone a project that has not been cloned yet.
+
+```bash
+gogo validate
+```
+
+---
+
 ## Examples
 
 ### Setting Up a New Meta Repository

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -2,8 +2,8 @@ import { Command } from 'commander';
 import { readFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { parse as parseYaml } from 'yaml';
-import { MetaConfigSchema, LoopRcSchema } from '../types/index.js';
-import { detectFormat, LOOPRC_FILE } from '../core/config.js';
+import { MetaConfigSchema, LoopRcSchema, type MetaConfig } from '../types/index.js';
+import { detectFormat, readMetaConfig, fileExists, LOOPRC_FILE } from '../core/config.js';
 import * as output from '../core/output.js';
 
 interface ValidationResult {
@@ -11,6 +11,9 @@ interface ValidationResult {
   valid: boolean;
   error?: string;
 }
+
+const MISSING_DIRECTORY_HINT =
+  "directory missing — run 'gogo migrate' if it moved, or 'gogo git update' to clone";
 
 function isGogoConfigFile(filename: string): boolean {
   return filename === '.gogo' || filename.startsWith('.gogo.');
@@ -63,9 +66,41 @@ export async function validateCommand(): Promise<void> {
     }
   }
 
-  if (hasErrors) {
+  const workingCopyHasErrors = await validateWorkingCopy(cwd);
+
+  if (hasErrors || workingCopyHasErrors) {
     throw new Error('Validation failed');
   }
+}
+
+async function validateWorkingCopy(cwd: string): Promise<boolean> {
+  let config: MetaConfig;
+  let metaDir: string;
+  try {
+    ({ config, metaDir } = await readMetaConfig(cwd));
+  } catch {
+    return false;
+  }
+
+  const projectPaths = Object.keys(config.projects);
+  if (projectPaths.length === 0) {
+    return false;
+  }
+
+  let hasErrors = false;
+  for (const projectPath of projectPaths) {
+    const projectDir = join(metaDir, projectPath);
+    if (!(await fileExists(projectDir))) {
+      output.projectStatus(projectPath, 'error', MISSING_DIRECTORY_HINT);
+      hasErrors = true;
+    }
+  }
+
+  if (!hasErrors) {
+    output.success(`All ${projectPaths.length} project directories present`);
+  }
+
+  return hasErrors;
 }
 
 async function validateConfigFile(filePath: string, filename: string): Promise<ValidationResult> {
@@ -110,7 +145,7 @@ async function validateLoopRcFile(filePath: string): Promise<ValidationResult> {
 export function registerValidateCommand(program: Command): void {
   program
     .command('validate')
-    .description('Validate all config files in the current directory')
+    .description('Validate config files and check that configured projects exist in the working copy')
     .action(async () => {
       await validateCommand();
     });

--- a/tests/integration/validate.test.ts
+++ b/tests/integration/validate.test.ts
@@ -38,6 +38,7 @@ describe('validate command', () => {
   it('validates a valid .gogo JSON file', async () => {
     vol.fromJSON({
       '/project/.gogo': JSON.stringify({ projects: { 'lib/foo': 'git@github.com:org/foo.git' } }),
+      '/project/lib/foo/.git': '',
     });
     const output = await import('../../src/core/output.js');
 
@@ -49,6 +50,7 @@ describe('validate command', () => {
   it('validates a valid .gogo.yaml file', async () => {
     vol.fromJSON({
       '/project/.gogo.yaml': 'projects:\n  lib/foo: git@github.com:org/foo.git\n',
+      '/project/lib/foo/.git': '',
     });
     const output = await import('../../src/core/output.js');
 
@@ -60,6 +62,7 @@ describe('validate command', () => {
   it('validates a valid .gogo.yml file', async () => {
     vol.fromJSON({
       '/project/.gogo.yml': 'projects:\n  lib/foo: git@github.com:org/foo.git\n',
+      '/project/lib/foo/.git': '',
     });
     const output = await import('../../src/core/output.js');
 
@@ -204,5 +207,100 @@ describe('validate command', () => {
 
     expect(output.projectStatus).toHaveBeenCalledTimes(1);
     expect(output.projectStatus).toHaveBeenCalledWith('.gogo', 'success');
+  });
+
+  describe('working copy validation', () => {
+    it('fails when a configured project directory is missing', async () => {
+      vol.fromJSON({
+        '/project/.gogo': JSON.stringify({
+          projects: { 'lib/foo': 'git@github.com:org/foo.git' },
+        }),
+      });
+      const output = await import('../../src/core/output.js');
+
+      await expect(validateCommand()).rejects.toThrow('Validation failed');
+
+      expect(output.projectStatus).toHaveBeenCalledWith(
+        'lib/foo',
+        'error',
+        expect.stringContaining('missing')
+      );
+    });
+
+    it('suggests how to fix a missing project directory', async () => {
+      vol.fromJSON({
+        '/project/.gogo': JSON.stringify({
+          projects: { 'lib/foo': 'git@github.com:org/foo.git' },
+        }),
+      });
+      const output = await import('../../src/core/output.js');
+
+      await expect(validateCommand()).rejects.toThrow('Validation failed');
+
+      const call = (output.projectStatus as ReturnType<typeof vi.fn>).mock.calls.find(
+        ([dir]) => dir === 'lib/foo'
+      );
+      expect(call?.[2]).toMatch(/gogo migrate/);
+      expect(call?.[2]).toMatch(/gogo git update/);
+    });
+
+    it('passes when all configured project directories exist', async () => {
+      vol.fromJSON({
+        '/project/.gogo': JSON.stringify({
+          projects: { 'lib/foo': 'git@github.com:org/foo.git' },
+        }),
+        '/project/lib/foo/.git': '',
+      });
+      const output = await import('../../src/core/output.js');
+
+      await expect(validateCommand()).resolves.toBeUndefined();
+
+      expect(output.projectStatus).not.toHaveBeenCalledWith(
+        'lib/foo',
+        'error',
+        expect.anything()
+      );
+    });
+
+    it('validates the working copy for a .gogo.yaml config', async () => {
+      vol.fromJSON({
+        '/project/.gogo.yaml': 'projects:\n  lib/foo: git@github.com:org/foo.git\n',
+      });
+      const output = await import('../../src/core/output.js');
+
+      await expect(validateCommand()).rejects.toThrow('Validation failed');
+
+      expect(output.projectStatus).toHaveBeenCalledWith(
+        'lib/foo',
+        'error',
+        expect.stringContaining('missing')
+      );
+    });
+
+    it('reports each missing project while keeping present ones quiet', async () => {
+      vol.fromJSON({
+        '/project/.gogo': JSON.stringify({
+          projects: {
+            'lib/present': 'git@github.com:org/present.git',
+            'lib/missing': 'git@github.com:org/missing.git',
+          },
+        }),
+        '/project/lib/present/.git': '',
+      });
+      const output = await import('../../src/core/output.js');
+
+      await expect(validateCommand()).rejects.toThrow('Validation failed');
+
+      expect(output.projectStatus).toHaveBeenCalledWith(
+        'lib/missing',
+        'error',
+        expect.stringContaining('missing')
+      );
+      expect(output.projectStatus).not.toHaveBeenCalledWith(
+        'lib/present',
+        'error',
+        expect.anything()
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary

Extends `gogo validate` so that, in addition to linting config-file syntax, it validates the configuration **against the current working copy**.

`gogo validate` now runs two phases:

1. **Config files** — every `.gogo` / `.gogo.*` / `.looprc` file in the current directory is parsed and schema-checked (unchanged behavior).
2. **Working copy** — each project declared in the resolved (`.gogo` + overlays) config must have a matching directory on disk.

When a configured project directory is missing, validation fails with a descriptive, actionable error:

```
✗ lib/foo  directory missing — run 'gogo migrate' if it moved, or 'gogo git update' to clone
```

This pairs with the new `gogo migrate` command (separate PR): `validate` detects mismatches, `migrate` reconciles the working copy to the config.

## Implementation

- New `validateWorkingCopy()` phase in `src/commands/validate.ts`. It reads the resolved config via `readMetaConfig()` and checks `fileExists()` for each project directory under the meta dir.
- The phase is a no-op when no resolvable primary meta file is present (e.g. only `.looprc` or only overlays), so syntax-only validation still works.
- Directory existence only — no git remotes are inspected in `validate` (that identity check lives in `migrate`).

## Testing

Developed with red-green TDD.

- Added 5 working-copy integration tests (missing dir fails; fix hint mentions both `gogo migrate` and `gogo git update`; all-present passes; `.gogo.yaml` resolution; mixed present/missing).
- Updated 3 pre-existing tests whose fixtures declared projects without creating the directories — they now create the directory to represent a valid working copy (the command's contract is intentionally extended).
- Full suite green: 168 unit + 82 integration. `typecheck` and `lint` clean.