### PR TITLE
feat(migrate): reconcile the working copy with the configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,35 @@ gogo validate
 
 ---
 
+### `gogo migrate`
+
+Reconcile the working copy with the configuration. After you re-arrange project
+paths in `.gogo` (rename or move entries while keeping the same repository URL),
+`gogo migrate` finds each repository at its current location and moves it to the
+path declared in the config. Repositories are matched by their `origin` remote
+URL, so renames and moves are detected automatically. Empty parent directories
+left behind by a move are removed.
+
+```bash
+gogo migrate            # Apply the moves
+gogo migrate --dry-run  # Show what would move without changing anything
+```
+
+Behavior:
+
+- **In sync** — a repository already at its configured path is left untouched.
+- **Moved/renamed** — a repository found at a different path is moved to match.
+- **Conflict** — if the target path is occupied by a *different* repository,
+  migration aborts without touching anything.
+- **Missing** — a configured repository that is not present anywhere in the
+  working copy is reported; run `gogo git update` to clone it.
+
+| Option       | Description                                          |
+| ------------ | ---------------------------------------------------- |
+| `--dry-run`  | Show what would be moved without making any changes  |
+
+---
+
 ## Examples
 
 ### Setting Up a New Meta Repository

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { registerGitCommands } from './commands/git/index.js';
 import { registerProjectCommands } from './commands/project/index.js';
 import { registerNpmCommands } from './commands/npm/index.js';
 import { registerValidateCommand } from './commands/validate.js';
+import { registerMigrateCommand } from './commands/migrate.js';
 import { setOverlayFiles } from './core/config.js';
 import * as output from './core/output.js';
 
@@ -51,6 +52,7 @@ export function createProgram(): Command {
   registerProjectCommands(program);
   registerNpmCommands(program);
   registerValidateCommand(program);
+  registerMigrateCommand(program);
 
   return program;
 }

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,0 +1,175 @@
+import { Command } from 'commander';
+import { mkdir, rename, readdir, rmdir } from 'node:fs/promises';
+import { join, dirname, resolve, sep } from 'node:path';
+import { execute } from '../core/executor.js';
+import { readMetaConfig, getMetaDir, fileExists } from '../core/config.js';
+import { findGitRepos } from '../core/discover.js';
+import * as output from '../core/output.js';
+
+interface MigrateOptions {
+  dryRun?: boolean;
+}
+
+interface Move {
+  from: string;
+  to: string;
+}
+
+interface Conflict {
+  path: string;
+  found: string | null;
+}
+
+async function pruneEmptyParents(metaDir: string, movedFrom: string): Promise<void> {
+  const root = resolve(metaDir);
+  let dir = resolve(dirname(join(metaDir, movedFrom)));
+
+  while (dir !== root && dir.startsWith(root + sep)) {
+    let entries: string[];
+    try {
+      entries = await readdir(dir);
+    } catch {
+      return;
+    }
+    if (entries.length > 0) {
+      return;
+    }
+    await rmdir(dir);
+    dir = dirname(dir);
+  }
+}
+
+async function getRemoteUrl(dir: string): Promise<string | null> {
+  const result = await execute('git remote get-url origin', { cwd: dir });
+  if (result.exitCode === 0 && result.stdout) {
+    return result.stdout.trim();
+  }
+  return null;
+}
+
+async function mapUrlsToCurrentPaths(
+  metaDir: string,
+  ignore: string[]
+): Promise<{ urlToPath: Map<string, string>; ambiguousUrls: Set<string> }> {
+  const repoPaths = await findGitRepos(metaDir, ignore);
+  const urlToPath = new Map<string, string>();
+  const ambiguousUrls = new Set<string>();
+
+  for (const repoPath of repoPaths) {
+    const url = await getRemoteUrl(join(metaDir, repoPath));
+    if (!url) {
+      continue;
+    }
+    if (urlToPath.has(url)) {
+      ambiguousUrls.add(url);
+      continue;
+    }
+    urlToPath.set(url, repoPath);
+  }
+
+  return { urlToPath, ambiguousUrls };
+}
+
+export async function migrateCommand(options: MigrateOptions = {}): Promise<void> {
+  const cwd = process.cwd();
+  const metaDir = await getMetaDir(cwd);
+
+  if (!metaDir) {
+    throw new Error('Not in a gogo-meta repository. Run "gogo init" first.');
+  }
+
+  const { config } = await readMetaConfig(cwd);
+  const desired = Object.entries(config.projects);
+
+  if (desired.length === 0) {
+    output.success('Working copy already matches configuration');
+    return;
+  }
+
+  const { urlToPath, ambiguousUrls } = await mapUrlsToCurrentPaths(metaDir, config.ignore);
+
+  const moves: Move[] = [];
+  const missing: string[] = [];
+  const conflicts: Conflict[] = [];
+  const ambiguous: string[] = [];
+
+  for (const [projectPath, url] of desired) {
+    const targetDir = join(metaDir, projectPath);
+
+    if (await fileExists(targetDir)) {
+      const targetRemote = await getRemoteUrl(targetDir);
+      if (targetRemote !== url) {
+        conflicts.push({ path: projectPath, found: targetRemote });
+      }
+      continue;
+    }
+
+    const currentPath = urlToPath.get(url);
+    if (ambiguousUrls.has(url)) {
+      ambiguous.push(projectPath);
+    } else if (currentPath && currentPath !== projectPath) {
+      moves.push({ from: currentPath, to: projectPath });
+    } else {
+      missing.push(projectPath);
+    }
+  }
+
+  if (conflicts.length > 0) {
+    for (const conflict of conflicts) {
+      output.projectStatus(
+        conflict.path,
+        'error',
+        `occupied by a different repository (found ${conflict.found ?? 'no remote'})`
+      );
+    }
+    throw new Error(
+      'Migration aborted: one or more target paths are occupied by a different repository'
+    );
+  }
+
+  if (moves.length === 0 && missing.length === 0 && ambiguous.length === 0) {
+    output.success('Working copy already matches configuration');
+    return;
+  }
+
+  for (const move of moves) {
+    if (options.dryRun) {
+      output.info(`Would move ${move.from} → ${move.to}`);
+      continue;
+    }
+    const targetDir = join(metaDir, move.to);
+    await mkdir(dirname(targetDir), { recursive: true });
+    await rename(join(metaDir, move.from), targetDir);
+    await pruneEmptyParents(metaDir, move.from);
+    output.projectStatus(move.to, 'success', `moved from ${move.from}`);
+  }
+
+  for (const projectPath of ambiguous) {
+    output.warning(
+      `${projectPath}: multiple working-copy directories share its repository URL — resolve manually`
+    );
+  }
+
+  for (const projectPath of missing) {
+    output.warning(`${projectPath} not found in working copy — run 'gogo git update' to clone`);
+  }
+
+  if (options.dryRun) {
+    output.info(`Dry run: ${moves.length} move(s) pending`);
+    return;
+  }
+
+  if (missing.length > 0 || ambiguous.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+export function registerMigrateCommand(program: Command): void {
+  program
+    .command('migrate')
+    .description('Move/rename working-copy directories to match the configuration')
+    .option('--dry-run', 'Show what would be moved without changing anything')
+    .action(async (options: { dryRun?: boolean }) => {
+      await migrateCommand({ dryRun: options.dryRun ?? false });
+    });
+}

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -2,7 +2,13 @@ import { Command } from 'commander';
 import { mkdir, rename, readdir, rmdir } from 'node:fs/promises';
 import { join, dirname, resolve, sep } from 'node:path';
 import { execute } from '../core/executor.js';
-import { readMetaConfig, getMetaDir, fileExists } from '../core/config.js';
+import {
+  readMetaConfig,
+  getMetaDir,
+  fileExists,
+  addToGitignore,
+  removeFromGitignore,
+} from '../core/config.js';
 import { findGitRepos } from '../core/discover.js';
 import * as output from '../core/output.js';
 
@@ -141,6 +147,8 @@ export async function migrateCommand(options: MigrateOptions = {}): Promise<void
     await mkdir(dirname(targetDir), { recursive: true });
     await rename(join(metaDir, move.from), targetDir);
     await pruneEmptyParents(metaDir, move.from);
+    await removeFromGitignore(metaDir, move.from);
+    await addToGitignore(metaDir, move.to);
     output.projectStatus(move.to, 'success', `moved from ${move.from}`);
   }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -295,3 +295,22 @@ export async function addToGitignore(metaDir: string, entry: string): Promise<bo
 
   return true;
 }
+
+export async function removeFromGitignore(metaDir: string, entry: string): Promise<boolean> {
+  const gitignorePath = join(metaDir, '.gitignore');
+
+  if (!(await fileExists(gitignorePath))) {
+    return false;
+  }
+
+  const content = await readFile(gitignorePath, 'utf-8');
+  const lines = content.split('\n');
+  const filtered = lines.filter((line) => line.trim() !== entry);
+
+  if (filtered.length === lines.length) {
+    return false;
+  }
+
+  await writeFile(gitignorePath, filtered.join('\n'), 'utf-8');
+  return true;
+}

--- a/src/core/discover.ts
+++ b/src/core/discover.ts
@@ -1,0 +1,47 @@
+import { readdir } from 'node:fs/promises';
+import { join, relative, sep } from 'node:path';
+
+const GIT_DIR = '.git';
+
+function toPosixRelative(rootDir: string, dir: string): string {
+  return relative(rootDir, dir).split(sep).join('/');
+}
+
+/**
+ * Walk `rootDir` and return the paths (relative to `rootDir`, POSIX-style) of
+ * every directory that is a git repository. The root itself is never reported,
+ * discovered repositories are not descended into, and any directory whose name
+ * appears in `ignore` is skipped.
+ */
+export async function findGitRepos(rootDir: string, ignore: string[] = []): Promise<string[]> {
+  const ignoreSet = new Set(ignore);
+  const repos: string[] = [];
+
+  async function walk(dir: string): Promise<void> {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    const isRepo = entries.some((entry) => entry.name === GIT_DIR);
+    if (isRepo && dir !== rootDir) {
+      repos.push(toPosixRelative(rootDir, dir));
+      return;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      if (entry.name === GIT_DIR || ignoreSet.has(entry.name)) {
+        continue;
+      }
+      await walk(join(dir, entry.name));
+    }
+  }
+
+  await walk(rootDir);
+  return repos.sort();
+}

--- a/tests/integration/migrate.test.ts
+++ b/tests/integration/migrate.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import { migrateCommand } from '../../src/commands/migrate.js';
+
+vi.mock('node:fs/promises', async () => {
+  const memfs = await import('memfs');
+  return memfs.fs.promises;
+});
+
+vi.mock('../../src/core/executor.js', () => ({
+  execute: vi.fn(),
+}));
+
+vi.mock('../../src/core/output.js', () => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+  header: vi.fn(),
+  commandOutput: vi.fn(),
+  summary: vi.fn(),
+  projectStatus: vi.fn(),
+  bold: vi.fn((s: string) => s),
+}));
+
+const mockExecute = vi.fn();
+
+function withRemotes(remotes: Record<string, string>): void {
+  mockExecute.mockImplementation(async (_cmd: string, opts: { cwd: string }) => {
+    const url = remotes[opts.cwd];
+    return url
+      ? { exitCode: 0, stdout: url, stderr: '' }
+      : { exitCode: 1, stdout: '', stderr: 'no such remote' };
+  });
+}
+
+describe('migrate command', () => {
+  beforeEach(async () => {
+    vol.reset();
+    vi.clearAllMocks();
+    vi.spyOn(process, 'cwd').mockReturnValue('/project');
+
+    const executor = await import('../../src/core/executor.js');
+    (executor.execute as ReturnType<typeof vi.fn>).mockImplementation(mockExecute);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it('throws when not in a gogo-meta repository', async () => {
+    vol.fromJSON({ '/project/file.txt': '' });
+
+    await expect(migrateCommand()).rejects.toThrow('Not in a gogo-meta repository');
+  });
+
+  it('reports already in sync when the working copy matches the config', async () => {
+    vol.fromJSON({
+      '/project/.gogo': JSON.stringify({ projects: { api: 'git@github.com:org/api.git' } }),
+      '/project/api/.git': '',
+    });
+    withRemotes({ '/project/api': 'git@github.com:org/api.git' });
+    const output = await import('../../src/core/output.js');
+
+    await migrateCommand();
+
+    expect(output.success).toHaveBeenCalledWith(expect.stringContaining('already matches'));
+    expect(vol.existsSync('/project/api')).toBe(true);
+  });
+
+  it('moves a repo from its current path to the configured path', async () => {
+    vol.fromJSON({
+      '/project/.gogo': JSON.stringify({ projects: { 'packages/api': 'git@github.com:org/api.git' } }),
+      '/project/lib/api/.git': '',
+    });
+    withRemotes({ '/project/lib/api': 'git@github.com:org/api.git' });
+    const output = await import('../../src/core/output.js');
+
+    await migrateCommand();
+
+    expect(vol.existsSync('/project/packages/api/.git')).toBe(true);
+    expect(vol.existsSync('/project/lib/api')).toBe(false);
+    expect(output.projectStatus).toHaveBeenCalledWith(
+      'packages/api',
+      'success',
+      expect.stringContaining('lib/api')
+    );
+  });
+
+  it('removes a parent directory left empty by a move', async () => {
+    vol.fromJSON({
+      '/project/.gogo': JSON.stringify({ projects: { 'packages/api': 'git@github.com:org/api.git' } }),
+      '/project/lib/api/.git': '',
+    });
+    withRemotes({ '/project/lib/api': 'git@github.com:org/api.git' });
+
+    await migrateCommand();
+
+    expect(vol.existsSync('/project/lib')).toBe(false);
+  });
+
+  it('keeps a parent directory that still contains other repos after a move', async () => {
+    vol.fromJSON({
+      '/project/.gogo': JSON.stringify({
+        projects: {
+          'packages/api': 'git@github.com:org/api.git',
+          'lib/web': 'git@github.com:org/web.git',
+        },
+      }),
+      '/project/lib/api/.git': '',
+      '/project/lib/web/.git': '',
+    });
+    withRemotes({
+      '/project/lib/api': 'git@github.com:org/api.git',
+      '/project/lib/web': 'git@github.com:org/web.git',
+    });
+
+    await migrateCommand();
+
+    expect(vol.existsSync('/project/packages/api/.git')).toBe(true);
+    expect(vol.existsSync('/project/lib/web/.git')).toBe(true);
+    expect(vol.existsSync('/project/lib')).toBe(true);
+  });
+
+  it('does not move anything in dry-run mode', async () => {
+    vol.fromJSON({
+      '/project/.gogo': JSON.stringify({ projects: { 'packages/api': 'git@github.com:org/api.git' } }),
+      '/project/lib/api/.git': '',
+    });
+    withRemotes({ '/project/lib/api': 'git@github.com:org/api.git' });
+    const output = await import('../../src/core/output.js');
+
+    await migrateCommand({ dryRun: true });
+
+    expect(vol.existsSync('/project/lib/api')).toBe(true);
+    expect(vol.existsSync('/project/packages/api')).toBe(false);
+    expect(output.info).toHaveBeenCalledWith(expect.stringContaining('packages/api'));
+  });
+
+  it('refuses to migrate when the target path is occupied by a different repository', async () => {
+    vol.fromJSON({
+      '/project/.gogo': JSON.stringify({ projects: { api: 'git@github.com:org/api.git' } }),
+      '/project/api/.git': '',
+    });
+    withRemotes({ '/project/api': 'git@github.com:org/other.git' });
+    const output = await import('../../src/core/output.js');
+
+    await expect(migrateCommand()).rejects.toThrow(/Migration aborted/);
+
+    expect(output.projectStatus).toHaveBeenCalledWith(
+      'api',
+      'error',
+      expect.stringContaining('occupied')
+    );
+  });
+
+  it('warns and exits non-zero when a configured repo is not in the working copy', async () => {
+    vol.fromJSON({
+      '/project/.gogo': JSON.stringify({ projects: { api: 'git@github.com:org/api.git' } }),
+    });
+    withRemotes({});
+    const output = await import('../../src/core/output.js');
+
+    await migrateCommand();
+
+    expect(output.warning).toHaveBeenCalledWith(expect.stringContaining('gogo git update'));
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/tests/integration/migrate.test.ts
+++ b/tests/integration/migrate.test.ts
@@ -123,6 +123,21 @@ describe('migrate command', () => {
     expect(vol.existsSync('/project/lib')).toBe(true);
   });
 
+  it('updates .gitignore when a repo is moved', async () => {
+    vol.fromJSON({
+      '/project/.gogo': JSON.stringify({ projects: { 'packages/api': 'git@github.com:org/api.git' } }),
+      '/project/.gitignore': 'node_modules\nlib/api\n',
+      '/project/lib/api/.git': '',
+    });
+    withRemotes({ '/project/lib/api': 'git@github.com:org/api.git' });
+
+    await migrateCommand();
+
+    const gitignore = vol.readFileSync('/project/.gitignore', 'utf-8') as string;
+    expect(gitignore).not.toMatch(/^lib\/api$/m);
+    expect(gitignore).toMatch(/^packages\/api$/m);
+  });
+
   it('does not move anything in dry-run mode', async () => {
     vol.fromJSON({
       '/project/.gogo': JSON.stringify({ projects: { 'packages/api': 'git@github.com:org/api.git' } }),

--- a/tests/unit/core/config.test.ts
+++ b/tests/unit/core/config.test.ts
@@ -12,6 +12,7 @@ import {
   findMetaFileUp,
   fileExists,
   addToGitignore,
+  removeFromGitignore,
   ConfigError,
   normalizeCommand,
   getCommand,
@@ -192,6 +193,46 @@ describe('config', () => {
       const added = await addToGitignore('/project', 'api');
 
       expect(added).toBe(false);
+    });
+  });
+
+  describe('removeFromGitignore', () => {
+    it('removes a matching entry and preserves the rest', async () => {
+      vol.fromJSON({ '/project/.gitignore': 'node_modules\nlib/api\n' });
+
+      const removed = await removeFromGitignore('/project', 'lib/api');
+
+      expect(removed).toBe(true);
+      const content = vol.readFileSync('/project/.gitignore', 'utf-8') as string;
+      expect(content).toBe('node_modules\n');
+    });
+
+    it('returns false when the entry is absent', async () => {
+      vol.fromJSON({ '/project/.gitignore': 'node_modules\n' });
+
+      const removed = await removeFromGitignore('/project', 'lib/api');
+
+      expect(removed).toBe(false);
+      const content = vol.readFileSync('/project/.gitignore', 'utf-8') as string;
+      expect(content).toBe('node_modules\n');
+    });
+
+    it('returns false when no .gitignore exists', async () => {
+      vol.fromJSON({ '/project': null });
+
+      const removed = await removeFromGitignore('/project', 'lib/api');
+
+      expect(removed).toBe(false);
+    });
+
+    it('matches entries with surrounding whitespace', async () => {
+      vol.fromJSON({ '/project/.gitignore': 'node_modules\n  lib/api  \n' });
+
+      const removed = await removeFromGitignore('/project', 'lib/api');
+
+      expect(removed).toBe(true);
+      const content = vol.readFileSync('/project/.gitignore', 'utf-8') as string;
+      expect(content).toBe('node_modules\n');
     });
   });
 

--- a/tests/unit/core/discover.test.ts
+++ b/tests/unit/core/discover.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { vol } from 'memfs';
+import { findGitRepos } from '../../../src/core/discover.js';
+
+vi.mock('node:fs/promises', async () => {
+  const memfs = await import('memfs');
+  return memfs.fs.promises;
+});
+
+describe('findGitRepos', () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns an empty list when there are no git repositories', async () => {
+    vol.fromJSON({
+      '/project/.gogo': '{}',
+      '/project/docs/readme.md': 'hi',
+    });
+
+    expect(await findGitRepos('/project')).toEqual([]);
+  });
+
+  it('finds a git repository directly under the root', async () => {
+    vol.fromJSON({
+      '/project/api/.git': '',
+    });
+
+    expect(await findGitRepos('/project')).toEqual(['api']);
+  });
+
+  it('finds nested git repositories and reports paths relative to the root', async () => {
+    vol.fromJSON({
+      '/project/api/.git': '',
+      '/project/libs/shared/.git': '',
+    });
+
+    expect(await findGitRepos('/project')).toEqual(['api', 'libs/shared']);
+  });
+
+  it('does not report the root itself even when it is a git repository', async () => {
+    vol.fromJSON({
+      '/project/.git': '',
+      '/project/api/.git': '',
+    });
+
+    expect(await findGitRepos('/project')).toEqual(['api']);
+  });
+
+  it('does not recurse into a discovered repository', async () => {
+    vol.fromJSON({
+      '/project/api/.git': '',
+      '/project/api/vendor/nested/.git': '',
+    });
+
+    expect(await findGitRepos('/project')).toEqual(['api']);
+  });
+
+  it('skips ignored directory names', async () => {
+    vol.fromJSON({
+      '/project/api/.git': '',
+      '/project/node_modules/pkg/.git': '',
+    });
+
+    expect(await findGitRepos('/project', ['node_modules'])).toEqual(['api']);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `gogo migrate`, which moves/renames working-copy repositories to match the paths declared in `.gogo`. This is the companion to `gogo validate` (separate PR #35): `validate` detects when a configured project directory is missing; `migrate` reconciles the working copy with the config.

Repositories are identified by their `origin` remote URL, so re-arranging project paths in the config (rename/move) is detected and applied automatically.

```bash
gogo migrate            # Apply the moves
gogo migrate --dry-run  # Preview without changing anything
```

### Behavior

- **In sync** — a repo already at its configured path is left untouched.
- **Moved/renamed** — a repo found at a different path is moved to match. Missing parent directories are created; parents left empty by a move are pruned.
- **`.gitignore` upkeep** — since child paths are tracked in the meta repo's `.gitignore` (by `project import`/`create`), a move removes the old entry and adds the new one, so the moved repo stays ignored.
- **Conflict** — if the target path is occupied by a *different* repository (remote mismatch), migration aborts **before any move** and exits non-zero.
- **Missing** — a configured repo not present anywhere in the working copy is reported (suggesting `gogo git update`) and exits non-zero.

## Implementation

- New `findGitRepos` core helper (`src/core/discover.ts`) discovers repositories by walking the meta directory: skips ignored names, never descends into a discovered repo, never reports the meta root itself.
- New `removeFromGitignore` core helper alongside the existing `addToGitignore`.
- `src/commands/migrate.ts` builds a `remote-URL → current-path` map, diffs it against the configured paths, and applies moves.

## Testing

Developed with red-green TDD.

- `findGitRepos`: 6 unit tests (nesting, root exclusion, no-recurse-into-repo, ignore list).
- `removeFromGitignore`: 4 unit tests.
- `migrate` command: 9 integration tests (in sync, move, prune empty parent, keep non-empty parent, `.gitignore` upkeep, dry-run, conflict abort, missing, not-a-repo).
- Also verified end-to-end against real git repos: move + prune, idempotent re-run, conflict abort (exit 1), missing (exit 1), and `.gitignore`/`git status` correctness.
- Full suite green: 178 unit + 86 integration. `typecheck` and `lint` clean.

## Known limitations (intentional, called out for review)

- **Swaps / ambiguous URLs are not auto-resolved.** A true swap (`a`↔`b`) hits the occupied-target conflict and aborts; two directories sharing one remote URL warn and are skipped. Both are deliberately *safe* (no guessing), not oversights.
- **No rollback on partial failure.** Moves are applied sequentially; if one throws mid-run, earlier moves remain applied. Parents are `mkdir`-ed before each `rename`, so this is unlikely in practice.