### PR TITLE
refactor!: remove legacy .looprc support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,11 +114,3 @@ commands:
     cmd: npm test
     parallel: true
 ```
-
-### .looprc (optional filtering)
-
-```json
-{
-  "ignore": ["docs", "examples"]
-}
-```

--- a/README.md
+++ b/README.md
@@ -164,16 +164,6 @@ Overlay paths are resolved relative to the directory containing the primary conf
 
 Write commands (`project create`, `project import`) only modify the primary config file — overlay projects are never absorbed into it.
 
-### .looprc (optional)
-
-Define default ignore patterns for command execution:
-
-```json
-{
-  "ignore": ["docs", "examples"]
-}
-```
-
 ## Commands
 
 ### Global Options
@@ -567,8 +557,8 @@ gogo npm run lint --if-present
 
 Validate your configuration. This runs two checks:
 
-1. **Config files** — every `.gogo` / `.gogo.*` / `.looprc` file in the current
-   directory is parsed and checked against its schema.
+1. **Config files** — every `.gogo` / `.gogo.*` file in the current directory
+   is parsed and checked against its schema.
 2. **Working copy** — each project declared in the resolved config must have a
    matching directory on disk.
 

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -2,8 +2,8 @@ import { Command } from 'commander';
 import { readFile, readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { parse as parseYaml } from 'yaml';
-import { MetaConfigSchema, LoopRcSchema, type MetaConfig } from '../types/index.js';
-import { detectFormat, readMetaConfig, fileExists, LOOPRC_FILE } from '../core/config.js';
+import { MetaConfigSchema, type MetaConfig } from '../types/index.js';
+import { detectFormat, readMetaConfig, fileExists } from '../core/config.js';
 import * as output from '../core/output.js';
 
 interface ValidationResult {
@@ -29,10 +29,6 @@ export async function findConfigFiles(cwd: string): Promise<string[]> {
     }
   }
 
-  if (entries.includes(LOOPRC_FILE)) {
-    configFiles.push(LOOPRC_FILE);
-  }
-
   return configFiles.sort();
 }
 
@@ -44,11 +40,7 @@ export async function validateCommand(): Promise<void> {
 
   for (const filename of configFiles) {
     const filePath = join(cwd, filename);
-    if (filename === LOOPRC_FILE) {
-      results.push(await validateLoopRcFile(filePath));
-    } else {
-      results.push(await validateConfigFile(filePath, filename));
-    }
+    results.push(await validateConfigFile(filePath, filename));
   }
 
   if (results.length === 0) {
@@ -122,23 +114,6 @@ async function validateConfigFile(filePath: string, filename: string): Promise<V
       return { file: filename, valid: false, error: `Invalid structure: ${error.message}` };
     }
     return { file: filename, valid: false, error: String(error) };
-  }
-}
-
-async function validateLoopRcFile(filePath: string): Promise<ValidationResult> {
-  try {
-    const content = await readFile(filePath, 'utf-8');
-    const parsed = JSON.parse(content);
-    LoopRcSchema.parse(parsed);
-    return { file: LOOPRC_FILE, valid: true };
-  } catch (error) {
-    if (error instanceof SyntaxError) {
-      return { file: LOOPRC_FILE, valid: false, error: 'Invalid JSON' };
-    }
-    if (error instanceof Error && error.name === 'ZodError') {
-      return { file: LOOPRC_FILE, valid: false, error: `Invalid structure: ${error.message}` };
-    }
-    return { file: LOOPRC_FILE, valid: false, error: String(error) };
   }
 }
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,12 +1,11 @@
 import { readFile, writeFile, appendFile, access } from 'node:fs/promises';
 import { join, dirname, resolve } from 'node:path';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
-import { MetaConfigSchema, LoopRcSchema, type MetaConfig, type LoopRc, type CommandConfig, type ConfigFormat } from '../types/index.js';
+import { MetaConfigSchema, type MetaConfig, type CommandConfig, type ConfigFormat } from '../types/index.js';
 
 export type { ConfigFormat };
 
 export const META_FILE = '.gogo';
-export const LOOPRC_FILE = '.looprc';
 export const META_FILE_CANDIDATES = ['.gogo', '.gogo.yaml', '.gogo.yml'] as const;
 
 export class ConfigError extends Error {
@@ -185,22 +184,6 @@ export async function writeMetaConfig(cwd: string, config: MetaConfig, format: C
   const validated = MetaConfigSchema.parse(config);
   const content = serializeContent(validated, format);
   await writeFile(metaPath, content, 'utf-8');
-}
-
-export async function readLoopRc(cwd: string): Promise<LoopRc | null> {
-  const looprcPath = await findFileUp(LOOPRC_FILE, cwd);
-
-  if (!looprcPath) {
-    return null;
-  }
-
-  try {
-    const content = await readFile(looprcPath, 'utf-8');
-    const parsed = JSON.parse(content);
-    return LoopRcSchema.parse(parsed);
-  } catch {
-    return null;
-  }
 }
 
 export function getMetaDir(cwd: string): Promise<string | null> {

--- a/src/core/filter.ts
+++ b/src/core/filter.ts
@@ -59,18 +59,3 @@ export function createFilterOptions(options: {
     excludePattern: parseFilterPattern(options.excludePattern),
   };
 }
-
-export function filterFromLoopRc(
-  directories: string[],
-  ignore: string[]
-): string[] {
-  if (ignore.length === 0) {
-    return directories;
-  }
-
-  const ignoreSet = new Set(ignore);
-  return directories.filter((dir) => {
-    const dirBasename = basename(dir);
-    return !ignoreSet.has(dir) && !ignoreSet.has(dirBasename);
-  });
-}

--- a/src/core/loop.ts
+++ b/src/core/loop.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path';
 import { execute } from './executor.js';
 import { applyFilters } from './filter.js';
-import { getProjectPaths, readLoopRc } from './config.js';
+import { getProjectPaths } from './config.js';
 import * as output from './output.js';
 import type { MetaConfig, LoopOptions, LoopResult, ExecutorResult } from '../types/index.js';
 
@@ -124,12 +124,6 @@ export async function loop(
   options: LoopOptions = {}
 ): Promise<LoopResult[]> {
   let directories = getProjectPaths(context.config);
-
-  const loopRc = await readLoopRc(context.metaDir);
-  if (loopRc?.ignore) {
-    const ignoreSet = new Set(loopRc.ignore);
-    directories = directories.filter((dir) => !ignoreSet.has(dir));
-  }
 
   directories = applyFilters(directories, options);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,12 +29,6 @@ export const MetaConfigSchema = z.object({
 
 export type MetaConfig = z.infer<typeof MetaConfigSchema>;
 
-export const LoopRcSchema = z.object({
-  ignore: z.array(z.string()).default([]),
-});
-
-export type LoopRc = z.infer<typeof LoopRcSchema>;
-
 export interface FilterOptions {
   includeOnly?: string[] | undefined;
   excludeOnly?: string[] | undefined;

--- a/tests/integration/validate.test.ts
+++ b/tests/integration/validate.test.ts
@@ -71,17 +71,6 @@ describe('validate command', () => {
     expect(output.projectStatus).toHaveBeenCalledWith('.gogo.yml', 'success');
   });
 
-  it('validates a valid .looprc file', async () => {
-    vol.fromJSON({
-      '/project/.looprc': JSON.stringify({ ignore: ['docs'] }),
-    });
-    const output = await import('../../src/core/output.js');
-
-    await validateCommand();
-
-    expect(output.projectStatus).toHaveBeenCalledWith('.looprc', 'success');
-  });
-
   it('reports invalid JSON in .gogo', async () => {
     vol.fromJSON({
       '/project/.gogo': '{not valid json',
@@ -115,44 +104,31 @@ describe('validate command', () => {
     expect(output.projectStatus).toHaveBeenCalledWith('.gogo', 'error', expect.stringContaining('Invalid structure'));
   });
 
-  it('reports invalid JSON in .looprc', async () => {
-    vol.fromJSON({
-      '/project/.looprc': 'not json',
-    });
-    const output = await import('../../src/core/output.js');
-
-    await expect(validateCommand()).rejects.toThrow('Validation failed');
-
-    expect(output.projectStatus).toHaveBeenCalledWith('.looprc', 'error', 'Invalid JSON');
-  });
-
   it('validates multiple files at once', async () => {
     vol.fromJSON({
       '/project/.gogo': JSON.stringify({ projects: {} }),
       '/project/.gogo.yaml': 'projects:\n  lib/bar: git@github.com:org/bar.git\n',
-      '/project/.looprc': JSON.stringify({ ignore: [] }),
     });
     const output = await import('../../src/core/output.js');
 
     await validateCommand();
 
-    expect(output.projectStatus).toHaveBeenCalledTimes(3);
+    expect(output.projectStatus).toHaveBeenCalledTimes(2);
     expect(output.projectStatus).toHaveBeenCalledWith('.gogo', 'success');
     expect(output.projectStatus).toHaveBeenCalledWith('.gogo.yaml', 'success');
-    expect(output.projectStatus).toHaveBeenCalledWith('.looprc', 'success');
   });
 
   it('reports mix of valid and invalid files', async () => {
     vol.fromJSON({
       '/project/.gogo': JSON.stringify({ projects: {} }),
-      '/project/.looprc': 'broken',
+      '/project/.gogo.devops': '{broken',
     });
     const output = await import('../../src/core/output.js');
 
     await expect(validateCommand()).rejects.toThrow('Validation failed');
 
     expect(output.projectStatus).toHaveBeenCalledWith('.gogo', 'success');
-    expect(output.projectStatus).toHaveBeenCalledWith('.looprc', 'error', 'Invalid JSON');
+    expect(output.projectStatus).toHaveBeenCalledWith('.gogo.devops', 'error', 'Invalid JSON');
   });
 
   it('validates overlay config files like .gogo.devops.yaml', async () => {
@@ -182,17 +158,15 @@ describe('validate command', () => {
       '/project/.gogo': JSON.stringify({ projects: {} }),
       '/project/.gogo.devops.yaml': 'projects:\n  infra/cd: git@github.com:org/cd.git\n',
       '/project/.gogo.staging': JSON.stringify({ projects: { 'staging/app': 'git@github.com:org/app.git' } }),
-      '/project/.looprc': JSON.stringify({ ignore: [] }),
     });
     const output = await import('../../src/core/output.js');
 
     await validateCommand();
 
-    expect(output.projectStatus).toHaveBeenCalledTimes(4);
+    expect(output.projectStatus).toHaveBeenCalledTimes(3);
     expect(output.projectStatus).toHaveBeenCalledWith('.gogo', 'success');
     expect(output.projectStatus).toHaveBeenCalledWith('.gogo.devops.yaml', 'success');
     expect(output.projectStatus).toHaveBeenCalledWith('.gogo.staging', 'success');
-    expect(output.projectStatus).toHaveBeenCalledWith('.looprc', 'success');
   });
 
   it('ignores non-config files', async () => {

--- a/tests/unit/core/filter.test.ts
+++ b/tests/unit/core/filter.test.ts
@@ -4,7 +4,6 @@ import {
   parseFilterList,
   parseFilterPattern,
   createFilterOptions,
-  filterFromLoopRc,
 } from '../../../src/core/filter.js';
 
 describe('filter', () => {
@@ -169,26 +168,6 @@ describe('filter', () => {
       expect(result.excludeOnly).toBeUndefined();
       expect(result.includePattern).toBeUndefined();
       expect(result.excludePattern).toBeUndefined();
-    });
-  });
-
-  describe('filterFromLoopRc', () => {
-    it('removes directories in ignore list', () => {
-      const dirs = ['api', 'web', 'node_modules', '.git'];
-      const result = filterFromLoopRc(dirs, ['node_modules', '.git']);
-      expect(result).toEqual(['api', 'web']);
-    });
-
-    it('returns all directories when ignore list is empty', () => {
-      const dirs = ['api', 'web'];
-      const result = filterFromLoopRc(dirs, []);
-      expect(result).toEqual(dirs);
-    });
-
-    it('matches on basename', () => {
-      const dirs = ['libs/api', 'libs/node_modules'];
-      const result = filterFromLoopRc(dirs, ['node_modules']);
-      expect(result).toEqual(['libs/api']);
     });
   });
 });


### PR DESCRIPTION
## Summary

Removes the legacy `.looprc` config feature inherited from the original [meta](https://github.com/mateodelnorte/meta) tool. The core `loop()` orchestration engine (used by `exec`/`run`/`git`/`npm`) is **kept** — only its `.looprc` integration is removed.

Removed:

- `LoopRcSchema` / `LoopRc` type (`src/types/index.ts`)
- `LOOPRC_FILE` constant and `readLoopRc()` (`src/core/config.ts`)
- The per-loop `.looprc` ignore merge in `src/core/loop.ts`
- `filterFromLoopRc()` (`src/core/filter.ts`)
- `.looprc` handling in `gogo validate` (`validateLoopRcFile`, the file-discovery branch)
- `.looprc` documentation in `README.md` and `CLAUDE.md`
- Associated unit/integration tests

## ⚠️ Breaking change

`.looprc` is no longer read. `.looprc` was the **only** mechanism that excluded explicitly-listed projects from the command loop (the `.gogo` `ignore` array is not consumed by `loop()`). A repo that relied on a `.looprc` ignore list will now run `exec`/`run`/`git`/`npm` against the previously-excluded directories.

**Migration:** use the `--exclude-only` / `--exclude-pattern` filters, or remove the entries from the `projects` map in `.gogo`.

The commit carries a `BREAKING CHANGE:` footer so the release tooling bumps the major version accordingly.

## Verification

- Repo-wide `rg -i looprc` → no remaining references.
- `typecheck` and `lint` clean.
- Full suite green: 165 unit + 75 integration.
- Runtime smoke: `gogo validate` works without `.looprc`; `gogo exec` still runs across projects (confirming the `loop()` engine is intact).
- Kept `findFileUp` (a generic, tested public helper, not `.looprc`-specific) and `LoopContext.metaDir` (still used by the engine to resolve per-project cwd).

## ⚠️ Merge-order note (overlaps with open PRs)

This branch is cut from `main`, so it does **not** include the changes in the two open feature PRs:

- **#35 (`gogo validate` working-copy check)** overlaps in **both** `src/commands/validate.ts` and `tests/integration/validate.test.ts`. Whichever merges second will conflict; the resolved state must keep **both** #35's working-copy validation phase **and** this PR's `.looprc` removal (don't drop either half).
- **#36 (`gogo migrate`)** also touches `src/core/config.ts`, but a different region (`removeFromGitignore`), so that overlap should resolve cleanly.