### PR TITLE
ci: publish Homebrew cask to tap on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,3 +68,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ steps.tag.outputs.ref }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,6 +34,29 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 
+homebrew_casks:
+  - name: gogo
+    binaries:
+      - gogo
+    directory: Casks
+    homepage: 'https://github.com/daFish/gogo-meta'
+    description: 'Run commands across multiple Git repositories at once'
+    custom_block: |
+      depends_on macos: :monterey
+    hooks:
+      post:
+        install: |
+          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/gogo"] if OS.mac?
+    commit_author:
+      name: 'github-actions[bot]'
+      email: '41898282+github-actions[bot]@users.noreply.github.com'
+    commit_msg_template: 'chore: brew cask update for {{ .ProjectName }} {{ .Tag }}'
+    repository:
+      owner: daFish
+      name: homebrew-gogo-meta
+      branch: main
+      token: '{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}'
+
 dockers:
   - image_templates:
       - 'ghcr.io/dafish/gogo-meta:{{ .Version }}-amd64'


### PR DESCRIPTION
## What

Auto-publish the Homebrew cask to the [`daFish/homebrew-gogo-meta`](https://github.com/daFish/homebrew-gogo-meta)
tap on every release.

- **`.goreleaser.yaml`** — add a `homebrew_casks` block that regenerates and commits
  `Casks/gogo.rb` to the tap. A `postflight` hook strips `com.apple.quarantine` so the
  un-notarized darwin binary runs under Gatekeeper (confirmed necessary: without it the
  binary is SIGKILLed on first run).
- **`.github/workflows/release.yml`** — pass `HOMEBREW_TAP_GITHUB_TOKEN` to the GoReleaser
  step. The default `GITHUB_TOKEN` cannot write to the separate tap repo.

## Verification

- `goreleaser check` — config valid (only the pre-existing `dockers` deprecation remains).
- `goreleaser release --snapshot --clean --skip=docker,publish` — generated a correct
  `dist/homebrew/Casks/gogo.rb` with per-arch URLs/SHAs, `binary "gogo"`, and the
  quarantine `postflight` (not duplicated).

## Note

On the next release GoReleaser overwrites the hand-written `Casks/gogo.rb` currently in the
tap — that is the intended handoff.